### PR TITLE
Support custom services

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ title: Send Notification
 label: Notify TV
 ```
 
-- `target` is the name of the notify-service that should get called without the `notify.` domain. (For `notify.notify` put in `notify`, for `notify.telegram` put in `telegram`, etc.)
+- `target` is the name of the notify-service that should get called without the `notify.` domain. (For `notify.notify` put in `notify`, for `notify.telegram` put in `telegram`, etc. If your service is not under the `notify.` domain, use the full service name, example: `script.notify_tv`)
 - `label` is optional and controlls the placeholder text
 - `title` is optional and controlles the card title
 

--- a/notify-card.js
+++ b/notify-card.js
@@ -37,7 +37,12 @@ class NotifyCard extends HTMLElement {
   send(){
     let msg = this.content.querySelector("paper-input").value;
     for (let t of this.targets) {
-      this.hass.callService("notify", t, {message: msg, data: this.config.data});
+      let [domain, target = null] = t.split(".");
+      if(target === null){
+        target = domain;
+        domain = "notify";
+      }
+      this.hass.callService(domain, target, {message: msg, data: this.config.data});
     }
     this.content.querySelector("paper-input").value = "";
   }


### PR DESCRIPTION

### This PR allows the use of any custom service.

Use case:
An LG WebOS TV can display text notifications by using a custom service call.
To align the `notify` interface (which uses a `message` key) it's possible to create a script and use a template.
But since the domain is always `notify.` right now, the card can't be configured to send the data to a script, for example: `script.notify_tv`

This allows `notify` as the default domain, unless a service is specified with a `.` in it's name.

### Examples:

1. **Inferred Domain:**
The following will use `notify.telegram` - defaulting to `notify.` domain:

```yaml
type: 'custom:notify-card'
target:
- telegram
```

2. **Specified domain:**
The following will use `foo.bar` - acknowledging the `.` in the name and inferring the domain:

```yaml
type: 'custom:notify-card'
target:
- foo.bar
```

3. **Mixed:**
The following will use both `notify.telegram` defaulting to `notify.` domain AND `foo.bar` - acknowledging the `.` in the name and inferring the domain:

```yaml
type: 'custom:notify-card'
target:
- telegram
- foo.bar
```