### PR TITLE
support placeholders surrounded by other text

### DIFF
--- a/notify-card.js
+++ b/notify-card.js
@@ -62,8 +62,12 @@ class NotifyCard extends HTMLElement {
           )
         );
       }
-      
-      return dict in terms ? terms[dict] : dict;
+
+      for (const [key, value] of Object.entries(terms)) {
+        dict = dict.replaceAll(key, value);
+      }
+
+      return dict;
     };
 
 


### PR DESCRIPTION
I like the card, but I realized it only works if `$MSG` or `$TITLE` is the only content of the given data field, could you maybe consider supporting placeholders surrounded by other text?

With this change I was able to use a fixed URI prefix and then "abuse" the title input field as a way to select the notification icon.

P.S.: I'm not a JS developer so if you think the idea is good but the implementation isn't, you can reject this and do it better :)