### PR TITLE
Add group mode, fix card_title:false, improve event listener handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Notify Card for Lovelace/Home Assistant
 
-[!["Buy Me A Coffee"](https://img.shields.io/static/v1?label=donate&message=buymeacoffe&color=FFDD00&logo=buymeacoffee&style=flat-square)](https://buymeacoffee.com/bernikr)
+[!["Buy Me A Coffee"](https://img.shields.io/static/v1?label=donate&message=buymeacoffee&color=FFDD00&logo=buymeacoffee&style=flat-square)](https://buymeacoffee.com/bernikr)
 [!["Chat on Telegram"](https://img.shields.io/static/v1?label=chat&message=Telegram&color=26A5E4&logo=telegram&style=flat-square)](https://t.me/bernikr)
 
 This simple card allows you to notify any notification service manually from the dashboard.
@@ -8,26 +8,30 @@ This simple card allows you to notify any notification service manually from the
 ![card](card.jpg)
 
 ## Install
+
 ### Install via HACS
+
 1. Go to the "Frontend"-tab in HACS
 2. Click on "Explore & Add Repositories"
 3. Search for `Notify Card`
-5. Click "Install this Repository in HACS"
+4. Click "Install this Repository in HACS"
 
 ### Manual install
+
 1. Copy the `notify-card.js` file to your `config/www` folder
 2. Add a reference in the resource config:
 
-```
+```yaml
 resources:
   - url: /local/notify-card.js
     type: module
 ```
 
 ## Config
+
 Example config:
 
-```
+```yaml
 type: 'custom:notify-card'
 label: Notify TV
 card_title: Send Notification
@@ -39,15 +43,17 @@ data:
   title: "{{ title }}"
 ```
 
-- `action` is the name of the action (service) to be called
-- `data` is used to define the data that gets passed to the action. Any data can be entered here and home assistant templates are supported. (with `msg` and `title` as variables for the entered text and `user` for the current user object)
-- `label` is optional and controls the placeholder text
-- `card_title` is optional and controls the card title
-- `notification_title` is optional and can be used as a second textfield
+* `action` is the name of the action (service) to be called
+* `data` is used to define the data that gets passed to the action. Any data can be entered here and home assistant templates are supported. (with `msg` and `title` as variables for the entered text and `user` for the current user object)
+* `label` is optional and controls the placeholder text
+* `card_title` is optional and controls the card title. Set to `false` to hide the title entirely and remove the header padding
+* `icon` is optional and controls the send button icon (default: `mdi:send`)
+* `group` is optional. Set to `true` when embedding inside another card — removes the border, box shadow, and background so the card blends into its parent
+* `notification_title` is optional and can be used as a second textfield
 
 Minimal config:
 
-```
+```yaml
 type: 'custom:notify-card'
 action: notify.living_room_tv
 data:
@@ -56,7 +62,7 @@ data:
 
 For services that require an entity as a target:
 
-```
+```yaml
 type: 'custom:notify-card'
 action: tts.google_say
 data:
@@ -66,8 +72,8 @@ target:
 ```
 
 If you want a textfield to set the notification title with every message you can configure it like this:
-```
-...
+
+```yaml
 type: 'custom:notify-card'
 action: notify.living_room_tv
 data:
@@ -78,8 +84,32 @@ notification_title:
 ```
 
 If you want to change the label of the title textfield you can do that in the input parameter:
-```
-...
-notification_ title:
+
+```yaml
+notification_title:
   input: 'Put Title here'
+```
+
+To use a custom icon for the send button:
+
+```yaml
+type: 'custom:notify-card'
+action: notify.living_room_tv
+icon: mdi:bullhorn
+data:
+  message: "{{ msg }}"
+```
+
+To embed the card inside an entities card without a visible border or background:
+
+```yaml
+type: entities
+entities:
+  - entity: input_number.some_helper
+  - type: custom:notify-card
+    action: notify.living_room_tv
+    card_title: false
+    group: true
+    data:
+      message: "{{ msg }}"
 ```

--- a/notify-card.js
+++ b/notify-card.js
@@ -3,18 +3,20 @@ class NotifyCard extends HTMLElement {
     if (!config.target && (!config.action || !config.data)) {
       throw new Error('You need to define an action and data');
     }
+
     this.config = config;
 
     // support for legacy config
     if (!config.action && config.target) {
-      if (typeof this.config.target == "string") {
+      if (typeof this.config.target === "string") {
         this.targets = [this.config.target];
       } else if (Array.isArray(this.config.target)) {
-        this.targets = this.config.target
+        this.targets = this.config.target;
       } else {
         throw new Error('Target needs to be a list or single target');
       }
     }
+
     this.render();
   }
 
@@ -36,13 +38,19 @@ class NotifyCard extends HTMLElement {
     }
 
     // Guard against YAML passing false as the string "false"
-    const hasTitle = this.config.card_title !== false && this.config.card_title !== 'false';
+    const hasTitle =
+      this.config.card_title !== false &&
+      this.config.card_title !== 'false';
 
     // Only set header when card_title is not explicitly false
-    this.card.header = hasTitle ? (this.config.card_title ?? "Send Notification") : null;
+    this.card.header = hasTitle
+      ? (this.config.card_title ?? "Send Notification")
+      : null;
 
     // Adjust top padding based on whether a header is present
-    this.content.style.padding = hasTitle ? '0 16px 16px' : '16px';
+    this.content.style.padding = hasTitle
+      ? '0 16px 16px'
+      : '16px';
 
     // Remove border, shadow, and background when used inside another card (group mode)
     if (this.config.group) {
@@ -54,23 +62,35 @@ class NotifyCard extends HTMLElement {
     this.content.innerHTML = "";
 
     if (this.config.notification_title instanceof Object) {
-      let title_label = this.config.notification_title.input ?? "Notification Title"
+      const title_label =
+        this.config.notification_title.input ?? "Notification Title";
+
       this.content.innerHTML += `
-      <div style="display: flex">
-        <ha-textfield id="notification_title" style="flex-grow: 1" label="${title_label}"/>
-      </div>
-      `
+        <div style="display: flex">
+          <ha-input
+            id="notification_title"
+            style="flex-grow: 1"
+            label="${title_label}">
+          </ha-input>
+        </div>
+      `;
     }
 
-    let label = this.config.label ?? "Notification Text";
-    let icon = this.config.icon ?? "mdi:send";
+    const label = this.config.label ?? "Notification Text";
+    const icon = this.config.icon ?? "mdi:send";
+
     this.content.innerHTML += `
-    <div style="display: flex; align-items: center; gap: 8px;">
-      <ha-textfield id="notification_text" style="flex-grow: 1" label="${label}"></ha-textfield>
-      <ha-icon-button id="send_button">
-          <ha-icon icon="${icon}">
-      </ha-icon-button>
-    </div>
+      <div style="display: flex; align-items: center; gap: 8px;">
+        <ha-input
+          id="notification_text"
+          style="flex-grow: 1"
+          label="${label}">
+        </ha-input>
+
+        <ha-icon-button id="send_button">
+          <ha-icon icon="${icon}"></ha-icon>
+        </ha-icon-button>
+      </div>
     `;
 
     // Replace nodes to drop any previously attached event listeners before re-binding
@@ -82,20 +102,48 @@ class NotifyCard extends HTMLElement {
     const freshTextField = textField.cloneNode(true);
     textField.parentNode.replaceChild(freshTextField, textField);
 
-    freshSendBtn.addEventListener("click", this.send.bind(this), false);
-    freshTextField.addEventListener("keydown", this.keydown.bind(this), false);
+    freshSendBtn.addEventListener(
+      "click",
+      this.send.bind(this),
+      false
+    );
+
+    freshTextField.addEventListener(
+      "keydown",
+      this.keydown.bind(this),
+      false
+    );
   }
 
   send() {
-    const recursive_render_template = (data, variables, replacement_terms) => {
+    const recursive_render_template = (
+      data,
+      variables,
+      replacement_terms
+    ) => {
+
       if (Array.isArray(data)) {
-        return Promise.all(data.map(t => recursive_render_template(t, variables, replacement_terms)));
+        return Promise.all(
+          data.map(t =>
+            recursive_render_template(
+              t,
+              variables,
+              replacement_terms
+            )
+          )
+        );
       }
 
       if (typeof data === 'object' && data !== null) {
         return Promise.all(
           Object.entries(data)
-            .map(([k, v]) => recursive_render_template(v, variables, replacement_terms).then(nv => [k, nv]))
+            .map(([k, v]) =>
+              recursive_render_template(
+                v,
+                variables,
+                replacement_terms
+              ).then(nv => [k, nv])
+            )
         ).then(res => Object.fromEntries(res));
       }
 
@@ -103,60 +151,112 @@ class NotifyCard extends HTMLElement {
         for (const [key, value] of Object.entries(replacement_terms)) {
           data = data.replaceAll(key, value);
         }
+
         if (data.includes("{{") || data.includes("{%")) {
-          return this.hass.callApi("post", "template", { "template": data, "variables": variables });
+          return this.hass.callApi(
+            "post",
+            "template",
+            {
+              template: data,
+              variables: variables,
+            }
+          );
         }
       }
-      return Promise.resolve(data);
-    }
 
-    let msg = this.content.querySelector("#notification_text").value;
-    let title = this.content.querySelector("#notification_title")?.value ?? this.config.notification_title;
+      return Promise.resolve(data);
+    };
+
+    const msg =
+      this.content.querySelector("#notification_text").value;
+
+    const title =
+      this.content.querySelector("#notification_title")?.value ??
+      this.config.notification_title;
 
     if (this.config.action) {
-      let [domain, service] = this.config.action.split(".");
-      recursive_render_template(this.config.data, {
-        "msg": msg,
-        "title": title,
-        "user": this.hass.user,
-      }, {
-        // legacy support
-        "$MSG": msg,
-        "$TITLE": title,
-        // save on template rendering request for common cases
-        "{{ msg }}": msg,
-        "{{ title }}": title,
-        "{{ user.name }}": this.hass.user.name,
-      }).then(data => {
-        this.hass.callService(domain, service, data, this.config.target);
-      })
+      const [domain, service] =
+        this.config.action.split(".");
+
+      recursive_render_template(
+        this.config.data,
+        {
+          msg: msg,
+          title: title,
+          user: this.hass.user,
+        },
+        {
+          // legacy support
+          "$MSG": msg,
+          "$TITLE": title,
+
+          // save on template rendering request for common cases
+          "{{ msg }}": msg,
+          "{{ title }}": title,
+          "{{ user.name }}": this.hass.user.name,
+        }
+      ).then(data => {
+        this.hass.callService(
+          domain,
+          service,
+          data,
+          this.config.target
+        );
+      });
+
     } else {
       // support for legacy config
-      for (let t of this.targets) {
+      for (const t of this.targets) {
+
         let [domain, target = null] = t.split(".");
+
         if (target === null) {
           target = domain;
           domain = "notify";
         }
 
         if (domain === "tts") {
-          this.hass.callService(domain, target, { "entity_id": this.config.service, "media_player_entity_id": this.config.entity, "message": msg });
+          this.hass.callService(
+            domain,
+            target,
+            {
+              entity_id: this.config.service,
+              media_player_entity_id: this.config.entity,
+              message: msg,
+            }
+          );
+
         } else {
-          this.hass.callService(domain, target, { message: msg, title: title, data: this.config.data });
+          this.hass.callService(
+            domain,
+            target,
+            {
+              message: msg,
+              title: title,
+              data: this.config.data,
+            }
+          );
         }
       }
     }
 
-    this.content.querySelectorAll("ha-textfield").forEach(e => e.value = "");
+    this.content
+      .querySelectorAll("ha-input")
+      .forEach(e => e.value = "");
   }
 
   keydown(e) {
-    if (e.code == "Enter") this.send();
+    if (e.code === "Enter") {
+      this.send();
+    }
   }
 
   getCardSize() {
-    // One row for the text input, plus one if a notification title input is present
-    return this.config.notification_title instanceof Object ? 2 : 1;
+    // One row for the text input,
+    // plus one if a notification title input is present
+    return this.config.notification_title instanceof Object
+      ? 2
+      : 1;
   }
 }
 

--- a/notify-card.js
+++ b/notify-card.js
@@ -35,11 +35,14 @@ class NotifyCard extends HTMLElement {
       this.appendChild(this.card);
     }
 
+    // Guard against YAML passing false as the string "false"
+    const hasTitle = this.config.card_title !== false && this.config.card_title !== 'false';
+
     // Only set header when card_title is not explicitly false
-    this.card.header = this.config.card_title !== false ? (this.config.card_title ?? "Send Notification") : null;
+    this.card.header = hasTitle ? (this.config.card_title ?? "Send Notification") : null;
 
     // Adjust top padding based on whether a header is present
-    this.content.style.padding = this.config.card_title !== false ? '0 16px 16px' : '16px';
+    this.content.style.padding = hasTitle ? '0 16px 16px' : '16px';
 
     // Remove border, shadow, and background when used inside another card (group mode)
     if (this.config.group) {

--- a/notify-card.js
+++ b/notify-card.js
@@ -83,8 +83,10 @@ class NotifyCard extends HTMLElement {
       <div style="display: flex; align-items: center; gap: 8px;">
         <ha-input
           id="notification_text"
-          style="flex-grow: 1"
-          label="${label}">
+          style="flex-grow: 1;` +
+          // Balance ha-input box vertically with no title
+          (hasTitle ? '"' : ' padding-top: 8px;"') +
+          `label="${label}">
         </ha-input>
 
         <ha-icon-button id="send_button">

--- a/notify-card.js
+++ b/notify-card.js
@@ -48,6 +48,7 @@ class NotifyCard extends HTMLElement {
       : null;
 
     // Adjust top padding based on whether a header is present
+    // as per ha-card's default styles to maintain consistent spacing
     this.content.style.padding = hasTitle
       ? '0 16px 16px'
       : '16px';
@@ -79,17 +80,30 @@ class NotifyCard extends HTMLElement {
     const label = this.config.label ?? "Notification Text";
     const icon = this.config.icon ?? "mdi:send";
 
+    // Nudge internal styling as ha-input adds padding-bottom: 8px.
+    // That misaligns the send button when the title is present and breaks
+    // ha-card 16px all-round padding when the title is absent.
+    // If ha-input is ever fixed (as it should be...) then these two nudges
+    // can be removed and the default ha-input styling will work as expected.
+    const inputStyle = hasTitle
+      ? 'flex-grow: 1;'
+      : 'flex-grow: 1; padding-bottom: 0px;';
+
+    const buttonStyle = hasTitle
+      ? 'padding-bottom: 8px;'
+      : '';
+
     this.content.innerHTML += `
       <div style="display: flex; align-items: center; gap: 8px;">
         <ha-input
           id="notification_text"
-          style="flex-grow: 1;` +
-          // Balance ha-input box vertically with no title
-          (hasTitle ? '"' : ' padding-top: 8px;"') +
-          `label="${label}">
+          style="${inputStyle}"
+          label="${label}">
         </ha-input>
 
-        <ha-icon-button id="send_button">
+        <ha-icon-button
+          id="send_button"
+          style="${buttonStyle}">
           <ha-icon icon="${icon}"></ha-icon>
         </ha-icon-button>
       </div>

--- a/notify-card.js
+++ b/notify-card.js
@@ -18,15 +18,36 @@ class NotifyCard extends HTMLElement {
     this.render();
   }
 
+  set hass(hass) {
+    // Store hass reference for callService and callApi use in send()
+    this._hass = hass;
+  }
+
+  get hass() {
+    return this._hass;
+  }
+
   render() {
     if (!this.content) {
       this.card = document.createElement('ha-card');
       this.content = document.createElement('div');
-      this.content.style.padding = '0 16px 16px';
       this.card.appendChild(this.content);
       this.appendChild(this.card);
     }
-    this.card.header = this.config.card_title ?? "Send Notification";
+
+    // Only set header when card_title is not explicitly false
+    this.card.header = this.config.card_title !== false ? (this.config.card_title ?? "Send Notification") : null;
+
+    // Adjust top padding based on whether a header is present
+    this.content.style.padding = this.config.card_title !== false ? '0 16px 16px' : '16px';
+
+    // Remove border, shadow, and background when used inside another card (group mode)
+    if (this.config.group) {
+      this.card.style.border = 'none';
+      this.card.style.boxShadow = 'none';
+      this.card.style.background = 'transparent';
+    }
+
     this.content.innerHTML = "";
 
     if (this.config.notification_title instanceof Object) {
@@ -39,16 +60,27 @@ class NotifyCard extends HTMLElement {
     }
 
     let label = this.config.label ?? "Notification Text";
+    let icon = this.config.icon ?? "mdi:send";
     this.content.innerHTML += `
-    <div style="display: flex">   
+    <div style="display: flex; align-items: center; gap: 8px;">
       <ha-textfield id="notification_text" style="flex-grow: 1" label="${label}"></ha-textfield>
-      <ha-icon-button id="send_button" slot="suffix">
-          <ha-icon icon="mdi:send">
+      <ha-icon-button id="send_button">
+          <ha-icon icon="${icon}">
       </ha-icon-button>
     </div>
     `;
-    this.content.querySelector("#send_button").addEventListener("click", this.send.bind(this), false);
-    this.content.querySelector("#notification_text").addEventListener("keydown", this.keydown.bind(this), false)
+
+    // Replace nodes to drop any previously attached event listeners before re-binding
+    const sendBtn = this.content.querySelector("#send_button");
+    const freshSendBtn = sendBtn.cloneNode(true);
+    sendBtn.parentNode.replaceChild(freshSendBtn, sendBtn);
+
+    const textField = this.content.querySelector("#notification_text");
+    const freshTextField = textField.cloneNode(true);
+    textField.parentNode.replaceChild(freshTextField, textField);
+
+    freshSendBtn.addEventListener("click", this.send.bind(this), false);
+    freshTextField.addEventListener("keydown", this.keydown.bind(this), false);
   }
 
   send() {
@@ -117,6 +149,11 @@ class NotifyCard extends HTMLElement {
 
   keydown(e) {
     if (e.code == "Enter") this.send();
+  }
+
+  getCardSize() {
+    // One row for the text input, plus one if a notification title input is present
+    return this.config.notification_title instanceof Object ? 2 : 1;
   }
 }
 


### PR DESCRIPTION
Consolidated a few local tweaks, specifically:

- card_title: false now correctly suppresses the header and adjusts padding
- icon: added as a configuration option to change the icon being displayed
- group: true removes border/shadow/background for use inside other cards (consistent with mini-graph-card convention)
- Event listeners are now safe against stacking on re-render
- Added getCardSize() and set hass accessor per custom card spec
- Removed redundant slot="suffix" from the icon button